### PR TITLE
DTSW-4945 Ente-staging

### DIFF
--- a/packages/duckietown_msgs/msg/DroneControl.msg
+++ b/packages/duckietown_msgs/msg/DroneControl.msg
@@ -1,4 +1,4 @@
-#Roll Pitch Yaw(rate) Throttle Commands, simulating output from
+#Roll Pitch Yaw(rate) Throttle AUX1 AUX2 Commands, simulating output from
 #remote control. Values range from 1000 to 2000
 #which corespond to values from 0% to 100%
 
@@ -6,3 +6,5 @@ float32 roll
 float32 pitch
 float32 yaw
 float32 throttle
+float32 aux1
+float32 aux2

--- a/packages/duckietown_msgs/msg/DroneMotorCommand.msg
+++ b/packages/duckietown_msgs/msg/DroneMotorCommand.msg
@@ -10,7 +10,3 @@ int16 m1
 int16 m2
 int16 m3
 int16 m4
-
-# AUX commands
-int16 aux1
-int16 aux2

--- a/packages/duckietown_msgs/msg/DroneMotorCommand.msg
+++ b/packages/duckietown_msgs/msg/DroneMotorCommand.msg
@@ -1,4 +1,4 @@
-# PWM commands from the range defined on cleanflight for each motor
+# PWM commands from the range defined on cleanflight for each motor and two AUX channels
 Header header
 
 # range defined on cleanflight
@@ -10,3 +10,7 @@ int16 m1
 int16 m2
 int16 m3
 int16 m4
+
+# AUX commands
+int16 aux1
+int16 aux2


### PR DESCRIPTION
Adding AUX1 and AUX2 channels to the ROS message we send to the FC node. AUX1 is used to toggle ARM mode on/off.