### PR TITLE
DTSW-7839 Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr-check.yml
+++ b/.github/workflows/jira-pr-check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   check-jira-key:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/duckietown/dt-ros-commons/security/code-scanning/1](https://github.com/duckietown/dt-ros-commons/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
For this workflow, the single best non-functional-change fix is:

- In `.github/workflows/jira-pr-check.yml`, insert:
  - `permissions: {}`
- Place it after the `on:` block (or before `jobs:`), so it applies globally.

Why this is best here:
- The job only evaluates event payload values and does not need repository writes.
- `permissions: {}` is the minimal, strict setting CodeQL suggests when no token access is required.
- It avoids changing job logic and keeps behavior the same while reducing risk.

No imports, methods, or dependency changes are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
